### PR TITLE
Add Dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       - "UKHomeOffice/hocs-core"
     ignore:
       - dependency-name: "org.elasticsearch:*"
+      - dependency-name: "software.amazon.awssdk:auth"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"


### PR DESCRIPTION
Add an ignore rule for Dependabot for patch updates to the `software.amazon.awssdk:auth` library.