### PR TITLE
HOCS-6419: refactor and improve service

### DIFF
--- a/helm/hocs-casework-search-indexer/templates/_envs.tpl
+++ b/helm/hocs-casework-search-indexer/templates/_envs.tpl
@@ -3,16 +3,18 @@
   value: '-XX:MaxRAMPercentage=70 -Djava.security.egd=file:/dev/./urandom -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local'
 - name: SPRING_PROFILES_ACTIVE
   value: 'aws'
-- name: MODE
+- name: APP_BATCH_SIZE
+  value: {{ .Values.app.batch.size }}
+- name: APP_BATCH_INTERVAL
+  value: {{ .Values.app.batch.interval }}
+- name: APP_INDEX_BASELINE
+  value: {{ .Values.app.index.baseline }}
+- name: APP_INDEX_PREFIX
+  value: {{ .Values.app.index.prefix }}
+- name: APP_MODE
   value: {{ .Values.app.mode }}
-- name: NEW_INDEX
-  value: {{ .Values.app.newIndex }}
-- name: BATCH_SIZE
-  value: {{ .Values.app.batchSize }}
-- name: BATCH_INTERVAL
-  value: {{ .Values.app.batchInterval }}
-- name: ELASTICSEARCH_INDEX_PREFIX
-  value: '{{ tpl .Values.app.elasticPrefix . }}'
+- name: APP_DATACREATEDBEFORE
+  value: {{ .Values.app.dataCreatedBefore }}
 - name: DB_HOST
   valueFrom:
     secretKeyRef:

--- a/helm/hocs-casework-search-indexer/values.yaml
+++ b/helm/hocs-casework-search-indexer/values.yaml
@@ -1,5 +1,4 @@
 ---
-
 app:
   image:
     repository: quay.io/ukhomeofficedigital/hocs-casework-search-indexer
@@ -11,9 +10,10 @@ app:
       cpu: 2000m
       memory: 2048Mi
   mode: SINGULAR
-  newIndex: 'false'
-  batchSize: '200'
-  batchInterval: '500'
-  elasticPrefix: '{{ .Release.Namespace }}-latest'
-
-
+  index:
+    baseline:
+    prefix:
+  batch:
+    size: '200'
+    interval: '500'
+  dataCreatedBefore:

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/CommandLineAppStartupRunner.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/CommandLineAppStartupRunner.java
@@ -9,7 +9,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.exceptions.ElasticSearchFailureException;
-import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services.ETLService;
+import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services.EtlService;
+import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services.IndexService;
 
 import java.io.IOException;
 
@@ -18,18 +19,28 @@ import java.io.IOException;
 @Profile("!test")
 public class CommandLineAppStartupRunner implements CommandLineRunner {
 
-    private final ETLService etlService;
+    private final EtlService etlService;
+
+    private final IndexService indexService;
 
     private final ApplicationContext applicationContext;
 
-    public CommandLineAppStartupRunner(ETLService etlService, ApplicationContext applicationContext) {
+    public CommandLineAppStartupRunner(
+        EtlService etlService,
+        IndexService indexService,
+        ApplicationContext applicationContext) {
         this.etlService = etlService;
+        this.indexService = indexService;
         this.applicationContext = applicationContext;
     }
 
     @Override
     public void run(String... args) throws IOException, InterruptedException {
-        log.info("Application started");
+        log.warn("Waiting 20 seconds before starting migration (to allow for job to be cancelled if needed)...");
+        Thread.sleep(20000);
+
+        log.info("Migration started");
+        indexService.createIndexes();
         etlService.migrate();
         log.info("Migration completed successfully, exiting");
         System.exit(SpringApplication.exit(applicationContext, () -> 0));

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/repository/CaseRepository.java
@@ -3,10 +3,12 @@ package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.reposit
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model.CaseData;
 
 import javax.persistence.QueryHint;
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import static org.hibernate.jpa.QueryHints.*;
@@ -14,10 +16,16 @@ import static org.hibernate.jpa.QueryHints.*;
 @Repository
 public interface CaseRepository extends JpaRepository<CaseData, Integer> {
 
-    @Query("select distinct cd from CaseData cd " + "left join fetch cd.correspondents " + "left join fetch cd.topics " + "left join fetch cd.somuItems " + "where cd.deleted = false " + "order by cd.type, cd.uuid")
+    @Query("SELECT DISTINCT cd FROM CaseData cd "
+        + "LEFT JOIN FETCH cd.correspondents "
+        + "LEFT JOIN FETCH cd.topics "
+        + "LEFT JOIN FETCH cd.somuItems "
+        + "WHERE cd.deleted = false "
+        + "AND cd.created <= :createdDate "
+        + "ORDER BY cd.type, cd.uuid")
     @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
         @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true"),
         @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
-    Stream<CaseData> getAllCasesAndCollections();
+    Stream<CaseData> getAllCasesAndCollectionsBefore(@Param("createdDate") LocalDateTime createdDate);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/exceptions/ElasticSearchFailureException.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/exceptions/ElasticSearchFailureException.java
@@ -1,8 +1,9 @@
 package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.exceptions;
 
-public class ElasticSearchFailureException extends RuntimeException  {
+public class ElasticSearchFailureException extends RuntimeException {
 
     public ElasticSearchFailureException(String message, Throwable cause) {
         super(message, cause);
     }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/services/IndexService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/services/IndexService.java
@@ -1,0 +1,105 @@
+package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services;
+
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetIndexResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.CaseType;
+import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.IndexMode;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class IndexService {
+
+    private final RestHighLevelClient client;
+
+    private final String baselineIndex;
+
+    private final String prefix;
+
+    private final IndexMode indexMode;
+
+    private final String timestamp;
+
+    public IndexService(RestHighLevelClient client,
+                        @Value("${app.index.baseline}") String baselineIndex,
+                        @Value("${app.index.prefix}") String prefix,
+                        @Value("${app.mode}") IndexMode indexMode) {
+        this.client = client;
+        this.prefix = prefix;
+        this.indexMode = indexMode;
+        this.baselineIndex = baselineIndex;
+
+        var dateFormat = new SimpleDateFormat("yyyyMMddHHmm");
+        this.timestamp = dateFormat.format(Date.from(Instant.now()));
+
+        log.info("Baseline Index: {}", baselineIndex);
+        log.info("Indexing Mode: {}", indexMode);
+        log.info("Index prefix: {}", prefix);
+        log.info("Index timestamp: {}", timestamp);
+    }
+
+    public void createIndexes() throws IOException {
+        GetIndexResponse getIndexResponse =
+            client.indices().get(new GetIndexRequest(baselineIndex),
+            RequestOptions.DEFAULT);
+
+        var indexMapping = getIndexResponse.getMappings().get(baselineIndex).sourceAsMap();
+
+        if (indexMode == IndexMode.SINGULAR) {
+            createIndex(null, indexMapping, false);
+        } else {
+            for (CaseType caseType : CaseType.values()) {
+                createIndex(caseType.name(), indexMapping, true);
+            }
+        }
+    }
+
+    private void createIndex(String type, Map<String, Object> indexSourceMap, boolean multipleSearchAlias) throws IOException {
+        var indexName = getIndexName(type);
+
+        var createIndexRequest = new CreateIndexRequest(indexName)
+            .source(indexSourceMap)
+            .alias(new Alias(getTypeAliasName(type, true)).writeIndex(true))
+            .alias(new Alias(getTypeAliasName(type, false)).writeIndex(false));
+
+        if (multipleSearchAlias) {
+            createIndexRequest.alias(new Alias(getGlobalReadAliasName()).writeIndex(false));
+        }
+
+        log.info("Creating new index {}.", indexName);
+        client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
+    }
+
+    public String getIndexName(String type) {
+        if (indexMode == IndexMode.SINGULAR) {
+            return String.format("%s-%s-case", prefix, timestamp);
+        }
+
+        return String.format("%s-%s-%s", prefix, timestamp, type.toLowerCase());
+    }
+
+    private String getGlobalReadAliasName() {
+        return String.format("%s-%s-read", prefix, timestamp);
+    }
+
+    private String getTypeAliasName(String type, boolean write) {
+        if (indexMode == IndexMode.SINGULAR) {
+            return String.format("%s-%s-case-%s", prefix, timestamp, write ? "write" : "read");
+        }
+
+        return String.format("%s-%s-%s-%s", prefix, timestamp, type.toLowerCase(), write ? "write" : "read");
+    }
+
+}

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -1,12 +1,11 @@
-management:
-health:
-  elasticsearch:
-    enabled: false
-
 aws:
   region: eu-west-2
   es:
     host: localhost.localstack.cloud
     port: 4566
-    results-limit: 500
-    index-prefix: local
+
+app:
+  index:
+    baseline: local-case
+    prefix: local
+  data-created-before:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,12 @@ spring:
   datasource:
     url: jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.name:postgres}?currentSchema=${db.schema.name:casework}&user=${db.username:root}&password=${db.password:dev}&stringtype=unspecified
 
-mode: SINGULAR
-new-index: false
-batch.size: 1000
-batch.interval: 200
+app:
+  index:
+    baseline:
+    prefix:
+  mode: MULTIPLE
+  batch:
+    size: 1000
+    interval: 200
+  data-created-before:

--- a/src/test/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/integration/MigrateCaseDataMultiIndexTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/integration/MigrateCaseDataMultiIndexTest.java
@@ -4,16 +4,17 @@ import net.javacrumbs.jsonunit.core.Option;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
-import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services.ETLService;
+import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services.EtlService;
+import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.services.IndexService;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -25,7 +26,7 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.SqlConfig.TransactionMode.ISOLATED;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "mode=MULTIPLE" })
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "app.mode=MULTIPLE" })
 @ActiveProfiles({ "localstack", "test" })
 @Sql(scripts = "classpath:case/beforeTest.sql", config = @SqlConfig(transactionMode = ISOLATED))
 @Sql(scripts = "classpath:case/afterTest.sql",
@@ -37,20 +38,24 @@ class MigrateCaseDataMultiIndexTest {
     private RestHighLevelClient highLevelClient;
 
     @Autowired
-    private ETLService etlService;
+    private IndexService indexService;
 
-    @Value("${aws.es.index-prefix}")
-    private String prefix;
+    @Autowired
+    private EtlService etlService;
+
+    @BeforeAll
+    static void setup(@Autowired IndexService indexService) throws IOException {
+        indexService.createIndexes();
+    }
 
     @Test
-    void createsCaseDocumentFromCaseData() throws IOException, InterruptedException {
-
+    void createsCaseDocumentFromCaseData() throws IOException {
         String expectedJSON = Files.readString(
             new ClassPathResource("elastic-search/case-data.json").getFile().toPath());
 
         etlService.migrate();
 
-        var getRequest = new GetRequest(String.format("%s-test", prefix), "14915b78-6977-42db-b343-0915a7f412a1");
+        var getRequest = new GetRequest(indexService.getIndexName("test"), "14915b78-6977-42db-b343-0915a7f412a1");
         var getResponse = highLevelClient.get(getRequest, RequestOptions.DEFAULT);
         var responseJson = getResponse.getSourceAsString();
 
@@ -58,22 +63,21 @@ class MigrateCaseDataMultiIndexTest {
     }
 
     @Test()
-    void updatesCaseTypeIndexInMultipleMode() throws IOException, InterruptedException {
-
+    void updatesCaseTypeIndexInMultipleMode() throws IOException {
         etlService.migrate();
 
         var testIndexResponse = highLevelClient.get(
-            new GetRequest(String.format("%s-test", prefix), "14915b78-6977-42db-b343-0915a7f412a1"),
+            new GetRequest(indexService.getIndexName("test"), "14915b78-6977-42db-b343-0915a7f412a1"),
             RequestOptions.DEFAULT);
         assertThat(testIndexResponse.getSourceAsMap()).containsEntry("caseUUID", "14915b78-6977-42db-b343-0915a7f412a1");
 
         var testAIndexResponse = highLevelClient.get(
-            new GetRequest(String.format("%s-testa", prefix), "24915b78-6977-42db-b343-0915a7f412a1"),
+            new GetRequest(indexService.getIndexName("testa"), "24915b78-6977-42db-b343-0915a7f412a1"),
             RequestOptions.DEFAULT);
         assertThat(testAIndexResponse.getSourceAsMap()).containsEntry("caseUUID", "24915b78-6977-42db-b343-0915a7f412a1");
 
         var testBIndexResponse = highLevelClient.get(
-            new GetRequest(String.format("%s-testb", prefix), "34915b78-6977-42db-b343-0915a7f412a1"),
+            new GetRequest(indexService.getIndexName("testb"), "34915b78-6977-42db-b343-0915a7f412a1"),
             RequestOptions.DEFAULT);
         assertThat(testBIndexResponse.getSourceAsMap()).containsEntry("caseUUID", "34915b78-6977-42db-b343-0915a7f412a1");
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   jpa:
     properties:
@@ -20,7 +19,12 @@ spring:
     locations: classpath:/db/migration/postgresql
     schemas: ${db.schema.name:caseworkindexer}
 
-mode: MULTIPLE
-new-index: false
-batch.size: 5
-batch.interval: 0
+app:
+  index:
+    baseline: local-case
+    prefix: local
+  mode: MULTIPLE
+  batch:
+    size: 5
+    interval: 0
+  dataCreatedBefore: 2023-01-01T00:00:00.000Z


### PR DESCRIPTION
- Refactor out the index creation to own service.
- Add aliases on index creation that support read and write. For instances of multiple creation an additional global read alias is added.
- Change to repository method to utilise a createdDate to better support streaming of large data with pages.
- Support the ability to specify a baseline prefix for index creation.
- Pull out configuration logging to instantiation.
- Move the processing sleep to main command line runner and extend to 20 seconds wait.
- Add assertion to throw obvious error on failed case index.