### PR TITLE
Feature/hocs 6857 springboot upgrade3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'java'
 }
@@ -23,9 +23,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-json'
-    implementation 'com.vladmihalcea:hibernate-types-55:2.21.1'
+    implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.3'
-    implementation 'software.amazon.awssdk:auth:2.20.0'
+    implementation 'software.amazon.awssdk:auth:2.20.69'
     implementation "org.elasticsearch:elasticsearch:${elasticVersion}"
     implementation "org.elasticsearch.client:elasticsearch-rest-client:${elasticVersion}"
     implementation "org.elasticsearch:elasticsearch-core:${elasticVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.13'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot' version '3.1.5'
+    id 'io.spring.dependency-management' version '1.1.3'
     id 'java'
 }
 
@@ -33,7 +33,7 @@ dependencies {
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:${elasticVersion}"
     implementation "com.google.guava:guava:32.0.1-jre"
     annotationProcessor 'org.projectlombok:lombok'
-    annotationProcessor 'org.springframework:spring-context-indexer:5.3.23'
+    annotationProcessor 'org.springframework:spring-context-indexer:6.0.6'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.springframework.boot' version '3.2.0'
-    id 'org.springframework.boot' version '2.7.13'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'java'
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/configuration/LocalDateAttributeConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/configuration/LocalDateAttributeConverter.java
@@ -1,7 +1,7 @@
 package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.configuration;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.sql.Date;
 import java.time.LocalDate;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/configuration/LocalDateTimeAttributeConverter.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/configuration/LocalDateTimeAttributeConverter.java
@@ -1,7 +1,7 @@
 package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.configuration;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/CaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/CaseData.java
@@ -3,16 +3,17 @@ package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.*;
 import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
+import org.hibernate.usertype.UserType;
+
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@Convert(attributeName = "jsonb", converter = JsonBinaryType.class)
 @NoArgsConstructor
 @Entity
 @Table(name = "case_data")
@@ -39,7 +40,7 @@ public class CaseData implements Serializable {
     @Column(name = "deleted")
     private boolean deleted;
 
-    @Type(type = "jsonb")
+    @Type(value = UserType.class)
     @Column(name = "data", columnDefinition = "jsonb")
     private Map<String, String> dataMap = new HashMap<>(0);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/CaseData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/CaseData.java
@@ -2,10 +2,11 @@ package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.*;
-import org.hibernate.annotations.Type;
 
 import jakarta.persistence.*;
-import org.hibernate.usertype.UserType;
+
+import org.hibernate.type.SqlTypes;
+import org.hibernate.annotations.JdbcTypeCode;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 @Table(name = "case_data")
 @Getter
 @Setter
+@SuppressWarnings("JpaAttributeTypeInspection")
 public class CaseData implements Serializable {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,7 +42,7 @@ public class CaseData implements Serializable {
     @Column(name = "deleted")
     private boolean deleted;
 
-    @Type(value = UserType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "data", columnDefinition = "jsonb")
     private Map<String, String> dataMap = new HashMap<>(0);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/Correspondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/Correspondent.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/SomuItem.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/SomuItem.java
@@ -5,16 +5,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@Convert(attributeName = "jsonb", converter = JsonBinaryType.class)
 @NoArgsConstructor
 @Entity
 @Table(name = "somu_item")
@@ -36,7 +35,7 @@ public class SomuItem implements Serializable {
     @Column(name = "somu_uuid")
     private UUID somuUuid;
 
-    @Type(type = "jsonb")
+    @Type(value = JsonBinaryType.class)
     @Column(name = "data", columnDefinition = "jsonb")
     private Map<String, Object> data = new HashMap<>(0);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/SomuItem.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/SomuItem.java
@@ -4,9 +4,11 @@ import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.Type;
+import org.hibernate.annotations.JdbcTypeCode;
 
 import jakarta.persistence.*;
+import org.hibernate.type.SqlTypes;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +21,7 @@ import java.util.UUID;
 @Table(name = "somu_item")
 @Getter
 @Setter
+@SuppressWarnings("JpaAttributeTypeInspection")
 public class SomuItem implements Serializable {
 
     @Id
@@ -35,7 +38,7 @@ public class SomuItem implements Serializable {
     @Column(name = "somu_uuid")
     private UUID somuUuid;
 
-    @Type(value = JsonBinaryType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "data", columnDefinition = "jsonb")
     private Map<String, Object> data = new HashMap<>(0);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/Topic.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/model/Topic.java
@@ -2,7 +2,7 @@ package uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/repository/CaseRepository.java
@@ -26,8 +26,7 @@ public interface CaseRepository extends JpaRepository<CaseData, Integer> {
         + "AND cd.type IN :types "
         + "ORDER BY cd.type, cd.uuid")
     @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
-        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true"),
-        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true") })
     Stream<CaseData> getAllCasesAndCollectionsBefore(@Param("endDate") LocalDateTime endDate,
                                                      @Param("types") Set<String> types);
 
@@ -39,8 +38,9 @@ public interface CaseRepository extends JpaRepository<CaseData, Integer> {
         + "AND cd.type IN :types "
         + "ORDER BY cd.type, cd.uuid")
     @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
-        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true"),
-        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true")
+        //,@QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false")
+        })
     Stream<CaseData> getAllCasesAndCollections(@Param("types") Set<String> types);
 
     @Query("SELECT DISTINCT cd FROM CaseData cd "
@@ -52,8 +52,7 @@ public interface CaseRepository extends JpaRepository<CaseData, Integer> {
         + "AND cd.type IN :types "
         + "ORDER BY cd.type, cd.uuid")
     @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
-        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true"),
-        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true")})
     Stream<CaseData> getAllCasesAndCollectionsBetween(@Param("startDate") LocalDateTime startDate,
                                                      @Param("endDate") LocalDateTime endDate,
                                                      @Param("types") Set<String> types);
@@ -67,8 +66,7 @@ public interface CaseRepository extends JpaRepository<CaseData, Integer> {
         + "AND cd.type IN :types "
         + "ORDER BY cd.type, cd.uuid")
     @QueryHints(value = { @QueryHint(name = HINT_FETCH_SIZE, value = "500"),
-        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true"),
-        @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") })
+        @QueryHint(name = HINT_CACHEABLE, value = "false"), @QueryHint(name = HINT_READONLY, value = "true") })
     Stream<CaseData> getAllCasesAndCollectionsAfter(@Param("startDate") LocalDateTime createdDate,
                                                      @Param("types") Set<String> types);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/casework/repository/CaseRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model.CaseData;
 
-import javax.persistence.QueryHint;
+import jakarta.persistence.QueryHint;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Stream;

--- a/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/services/EtlService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocscaseworksearchindexer/domain/services/EtlService.java
@@ -22,8 +22,8 @@ import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model.To
 import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.repository.CaseRepository;
 import uk.gov.digital.ho.hocs.hocscaseworksearchindexer.domain.casework.model.CaseData;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Arrays;


### PR DESCRIPTION
Feature/hocs 6857 springboot upgrade3 and build changes included as below: 
1. Upgrade spring boot to 3.2.0
2. com.vladmihalcea:hibernate-types from 55 to 60 version
3. software.amazon.awssdk:auth from 2.20.60 to 2.20.69
4. org.springframework:spring-context-indexer from 5.3.23 to 6.0.6

Build changes as below: 
1. javax package replaced by jakarta
2. @TypeDef and typeClass replaced by Converter and converter
3. @Type(type = "jsonb") replaced by @JdbcTypeCode(SqlTypes.JSON)
4. @SuppressWarnings("JpaAttributeTypeInspection") to avoid compilation error warning in Map data column name - even if I comment this there is no issues in running the code and this is purely Intellij bug [https://youtrack.jetbrains.com/issue/IDEA-270687]
5. Removed @QueryHint(name = HINT_PASS_DISTINCT_THROUGH, value = "false") as this has been removed in latest version 
[https://docs.jboss.org/hibernate/orm/6.0/migration-guide/migration-guide.html]

DISTINCT
Starting with Hibernate ORM 6 it is no longer necessary to use distinct in JPQL and HQL to filter out the same parent entity references when join fetching a child collection. The returning duplicates of entities are now always filtered by Hibernate.

Which means that for instance it is no longer necessary to set QueryHints#HINT_PASS_DISTINCT_THROUGH to false in order to skip the entity duplicates without producing a distinct in the SQL query.

From Hibernate ORM 6, distinct is always passed to the SQL query and the flag QueryHints#HINT_PASS_DISTINCT_THROUGH has been removed.